### PR TITLE
Rdf failure

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
       "facet.mincount" => "1",
       "facet.limit" => "-1"
     })
+    $rdf_ready = Relationships.new.ready
   end
 
   private

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -54,8 +54,14 @@ class PeopleController < ApplicationController
     @cases = $solr.query({:q => "personID_ss:#{id}", :fq => "recordType_s:caseid"})
 
     respond_to do |format|
-      format.html { 
-        @rdfresults = JSON.parse(Relationships.new.query_one_removed(id)) 
+      format.html {
+        # only display this error in HTML to allow for local testing
+        # and usability of the website for average users
+        begin
+          @rdfresults = JSON.parse(Relationships.new.query_one_removed(id))
+        rescue
+          @rdfresults = nil
+        end
       }
       format.json { render :json => Relationships.new.query_one_removed(id) }
       format.xml { render :xml => Relationships.new.query_one_removed(id, "xml") }

--- a/app/models/relationships.rb
+++ b/app/models/relationships.rb
@@ -21,7 +21,7 @@ class Relationships
 
     test_query = self.query("{ ?s ?p ?o } LIMIT 1")
     @ready = !test_query.nil?
-    puts "Warning: Connection with RDF server not established!" if !@ready
+    Rails.logger.error "Warning: Connection with RDF server not established!" if !@ready
   end
 
   def query(query_string, include_owl=false, format="json", order_by=nil)
@@ -30,7 +30,7 @@ class Relationships
     begin
       return Net::HTTP.get(URI.parse(url))
     rescue => e
-      puts "There was an error while querying rdf / parsing: #{e}"
+      Rails.logger.error "There was an error while querying rdf / parsing: #{e}"
       return nil
     end
   end

--- a/app/models/relationships.rb
+++ b/app/models/relationships.rb
@@ -7,6 +7,7 @@
 # so that's how we come to be here, today
 
 class Relationships
+  attr_reader :ready
   attr_accessor :rdf_file, :owl_file, :sparqler, :prefixes
 
   def initialize
@@ -17,6 +18,10 @@ class Relationships
     @prefixes = %{PREFIX #{CONFIG['prefix_owl']} 
                  PREFIX #{CONFIG['prefix_rdf']}
                  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>}
+
+    test_query = self.query("{ ?s ?p ?o } LIMIT 1")
+    @ready = !test_query.nil?
+    puts "Warning: Connection with RDF server not established!" if !@ready
   end
 
   def query(query_string, include_owl=false, format="json", order_by=nil)

--- a/app/views/people/connection_type.erb
+++ b/app/views/people/connection_type.erb
@@ -30,5 +30,9 @@ Find people related by a specific type of connection in the OSCYS data.
     </table>
   </div>
 <% elsif params[:type] %>
-  <h4>No results found</h4>
+  <% if $rdf_ready %>
+    <h4>No results found</h4>
+  <% else %>
+    <h4>Relationships currently unavailable</h4>
+  <% end %>
 <% end %>

--- a/app/views/people/network.html.erb
+++ b/app/views/people/network.html.erb
@@ -105,7 +105,7 @@
       </div>
     <% else %>
       <div id="no-relationship">
-        <h4>No relationships of this type found.</h4>
+        <h4>No relationships of this type found. Network may be currently unavailable.</h4>
       </div>
     <% end %> 
 

--- a/app/views/people/relationships.html.erb
+++ b/app/views/people/relationships.html.erb
@@ -14,7 +14,7 @@ Find connections up to four removed for attorneys in the OSCYS data.
   </div>
 <% end %>
 
-<% if params["per1id"] && params["per2id"] %>
+<% if $rdf_ready && params["per1id"] && params["per2id"] %>
 
 <!-- Navigate relationships -->
   <div class="jump_menu">
@@ -119,4 +119,6 @@ Find connections up to four removed for attorneys in the OSCYS data.
       <% end %>
     </table>
   <% end %>
+<% else %>
+  <p>Relationship connections currently unavailable</p>
 <% end %>  <%# end checking if any RDF results should be displayed %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -15,8 +15,8 @@
   
     <%= '<a href="#cases">Related Cases</a>'.html_safe if @cases[:docs].length > 0 %>
     <%= '<a href="#documents">Related Documents</a>'.html_safe if @docs[:docs].length > 0 %> 
-    <%= '<a href="#visualizations">Visualization</a>'.html_safe if @rdfresults["results"]["bindings"].length > 0 %>
-    <%= '<a href="#relationships">Relationships</a>'.html_safe if @rdfresults["results"]["bindings"].length > 0 %>
+    <%= '<a href="#visualizations">Visualization</a>'.html_safe if @rdfresults && @rdfresults["results"]["bindings"].length > 0 %>
+    <%= '<a href="#relationships">Relationships</a>'.html_safe if @rdfresults && @rdfresults["results"]["bindings"].length > 0 %>
   </div>
   
   <div class="row">
@@ -157,14 +157,16 @@
   	  
     </div><!--/column-->
     <div class="col-md-6">
-      <% if @rdfresults["results"]["bindings"].length > 0 %>
+      <% if @rdfresults && @rdfresults["results"]["bindings"].length > 0 %>
 	      <%= link_to "<div class='btn btn-default btn-lg btn-block' id='visualizations'>Visualize Relationships</div>".html_safe, network_vis_path(@person["id"]), class: "visualize_link", role: "button"  %>
-      <% end %>	  
+      <% else %>
+        <div class="btn btn-default btn-lg btn-block" id="visualizations">Relationship visualization<br/>currently unavailable</div>
+      <% end %>
 	  
       <!-- Relationships -->
       <a name="relationships"></a>
-      <% if @rdfresults["results"]["bindings"].length > 0 %>
-        <h3>Relationships:</h3>
+      <h3>Relationships:</h3>
+      <% if @rdfresults && @rdfresults["results"]["bindings"].length > 0 %>
         <% if @rdfresults && @rdfresults["results"] && @rdfresults["results"]["bindings"] %>
           <ul>
           <%# TODO clean this huge mess up %>
@@ -174,6 +176,8 @@
           <% end %>
           </ul>
         <% end %>
+      <% else %>
+        <p>Relationship information currently unavailable</p>
       <% end %>
     </div><!--/column-->
   </div><!--/row-->


### PR DESCRIPTION
checks on app start if the RDF has been successfully contacted
Note: after some testing this appears to only work if the server is totally down, rather than if you have misspelled a sub-uri

if rdf is not down, disables features of the site with error messages rather than causing site breaking exceptions