### PR TITLE
Visualization Update

### DIFF
--- a/app/assets/javascripts/hypertree.js
+++ b/app/assets/javascripts/hypertree.js
@@ -192,6 +192,7 @@ var initHypertree = function() {
       onBeforePlotNode: function(node) {
         var nodeDepth = node._depth;
         var color = nodeColors[nodeDepth];
+        // this appears to only affect the primary individual's node
         node.Node.color = color ? color : nodeColors["default"];
       },
       onBeforePlotLine: function(adj) {

--- a/app/assets/stylesheets/hypertree.css
+++ b/app/assets/stylesheets/hypertree.css
@@ -55,7 +55,7 @@ a {
 }
 
 .vis-notice {
-	background-color: #FFA500;
+	background-color: #F5CB7D;
 	font-size: 14px;
 	padding: 5px;
 	text-align: center;

--- a/app/assets/stylesheets/hypertree.css
+++ b/app/assets/stylesheets/hypertree.css
@@ -54,6 +54,13 @@ a {
 	overflow: hidden;
 }
 
+.vis-notice {
+	background-color: #FFA500;
+	font-size: 14px;
+	padding: 5px;
+	text-align: center;
+}
+
 /* Might not need this -KMD */
 #infovis {
 	width: 100%;

--- a/app/assets/stylesheets/style.scss.erb
+++ b/app/assets/stylesheets/style.scss.erb
@@ -837,6 +837,12 @@ a.cas, a.cas:visited, a.cas:active {
 	color: #911002;
 }
 
+#visualize_warning {
+	background-color: rgb(240, 173, 78);
+	font-size: 14px;
+	padding: 10px;
+}
+
 /* About */
 
 /* Fake code boxes for _data.html.erb */

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -78,7 +78,9 @@ class PeopleController < ApplicationController
     @person_url = request.base_url + network_vis_path.sub(/per\.[0-9]{6}/, "")
     respond_to do |format|
       format.html { 
-        @res = $rdf_ready ? Hypertree.new(@id, true).json : nil
+        hypertree_info = $rdf_ready ? Hypertree.new(@id, true).json : nil
+        @res = hypertree_info[:info]
+        @notes = hypertree_info[:notes]
         # optional to avoid all the header / footer
         render layout: false
       }

--- a/app/models/hypertree.rb
+++ b/app/models/hypertree.rb
@@ -6,6 +6,7 @@ class Hypertree < Relationships
     @id = person
     @omit = omit
     @type = type
+    @num_allowed = 40
     # we are taking the "types" out of the hypertree
     # but we could add it back in the future
     # raw_res = query_two_removed(person, "json", type)
@@ -19,6 +20,7 @@ class Hypertree < Relationships
   def format_results(raw_json)
     # expects results from self.class.query_two_removed in ruby json form
     info = {}
+    notes = ""
     # get the actual results
     bindings = raw_json["results"] && raw_json["results"]["bindings"] ? raw_json["results"]["bindings"] : nil
     if bindings.nil?
@@ -76,9 +78,14 @@ class Hypertree < Relationships
           end
         end
       end
+      # if per0's initial relationships exceed allowed number, disable outer ring
+      if info["children"].length > @num_allowed
+        notes = "Due to number of relationships, only displaying first level of familiarity"
+        info["children"].each { |c| c["children"] = [] }
+      end
     end
     # File.open("scripts/test_output.json", "w") { |file| file.write(info.to_json) }
-    return info
+    { info: info, notes: notes }
   end
 
   def _new_person(id, name, level, relation=nil, relationType=nil, children_exist=false, first=false)

--- a/app/models/hypertree.rb
+++ b/app/models/hypertree.rb
@@ -39,48 +39,46 @@ class Hypertree < Relationships
         per1to2 = _value(res["rel12"])
         rel01type = _value(res["rel01type"])
         rel12type = _value(res["rel12type"])
-        # if this is a judge / clerk relationship, omit
         # TODO make a generic function that can do per01 and per12 and potentially more
-        if !_omit_rel?(per0to1)
-          per1index = info["children"].find_index { |child| child["id"] == per1 }
-          per1obj = {}  # this needs to be available to the person two code below
-          # if person 1 has not been added, add to the original person's children
-          # otherwise, just grab person 1 out of the info hash
-          if per1index.nil?
-            info["children"] << _new_person(per1, _value(res["name1"]), 1, per0to1, rel01type, true)
-            per1obj = info["children"].last
-          else
-            per1obj = info["children"][per1index]
-            # this person might have multiple relationships with same individual
-            # for example, Ben petitionerAgainst Scott, Ben enslavedBy Scott
-            per1obj["data"]["relation"] += " / #{per0to1}" if !per1obj["data"]["relation"].include?(per0to1)
-            if !per1obj["data"]["relationType"].include?(rel01type)
-              addType = per1obj["data"]["relationType"].empty? ? rel01type : " / #{rel01type}"
-              per1obj["data"]["relationType"] += addType
-            end
+        per1index = info["children"].find_index { |child| child["id"] == per1 }
+        per1obj = {}  # this needs to be available to the person two code below
+        # if person 1 has not been added, add to the original person's children
+        # otherwise, just grab person 1 out of the info hash
+        if per1index.nil?
+          info["children"] << _new_person(per1, _value(res["name1"]), 1, per0to1, rel01type, true)
+          per1obj = info["children"].last
+        else
+          per1obj = info["children"][per1index]
+          # this person might have multiple relationships with same individual
+          # for example, Ben petitionerAgainst Scott, Ben enslavedBy Scott
+          per1obj["data"]["relation"] += " / #{per0to1}" if !per1obj["data"]["relation"].include?(per0to1)
+          if !per1obj["data"]["relationType"].include?(rel01type)
+            addType = per1obj["data"]["relationType"].empty? ? rel01type : " / #{rel01type}"
+            per1obj["data"]["relationType"] += addType
           end
+        end
 
-          # person 2 could potentially be showing up more than once if there are multiple relationships
-          if !_omit_rel?(per1to2)
-            per2index = per1obj["children"].find_index { |child| child["id"] == per2 }
-            # if person 2 has not been added, just shove it in, otherwise, add to existing
-            if per2index.nil?
-              per1obj["children"] << _new_person(per2, _value(res["name2"]), 2, per1to2, rel12type)
-            else
-              per2obj = per1obj["children"][per2index]
-              # account for multiple relationships with same individual
-              per2obj["data"]["relation"] += " / #{per1to2}" if !per2obj["data"]["relation"].include?(per1to2)
-              if !per2obj["data"]["relationType"].include?(rel12type)
-                addType = per2obj["data"]["relationType"].empty? ? rel12type : " / #{rel12type}"
-                per2obj["data"]["relationType"] += addType
-              end
-            end
+        # person 2 could potentially be showing up more than once if there are multiple relationships
+        per2index = per1obj["children"].find_index { |child| child["id"] == per2 }
+        # if person 2 has not been added, just shove it in, otherwise, add to existing
+        if per2index.nil?
+          per1obj["children"] << _new_person(per2, _value(res["name2"]), 2, per1to2, rel12type)
+        else
+          per2obj = per1obj["children"][per2index]
+          # account for multiple relationships with same individual
+          per2obj["data"]["relation"] += " / #{per1to2}" if !per2obj["data"]["relation"].include?(per1to2)
+          if !per2obj["data"]["relationType"].include?(rel12type)
+            addType = per2obj["data"]["relationType"].empty? ? rel12type : " / #{rel12type}"
+            per2obj["data"]["relationType"] += addType
           end
         end
       end
       # if per0's initial relationships exceed allowed number, disable outer ring
       if info["children"].length > @num_allowed
-        notes = "Due to number of relationships, only displaying first level of familiarity"
+        notes = <<-TEXT
+          Due to a large number of relationships,
+          only the first level of familiarity is being displayed.
+        TEXT
         # for each of the first ring's children, empty out the dataset
         # so that they will not be displayed
         info["children"].each do |c|
@@ -101,7 +99,7 @@ class Hypertree < Relationships
       if omitted.length > 0
         notes = <<-TEXT
           Due to a large number of relationships,
-          these relationship networks have been omitted:
+          individuals related to the following people have been omitted:
         TEXT
         notes += omitted.join("; ")
       end
@@ -121,10 +119,6 @@ class Hypertree < Relationships
     person["data"]["relationType"] = relationType if !relationType.nil?
     person["data"]["original_element"] = first
     return person
-  end
-
-  def _omit_rel?(rel)
-    return rel == "judgeOf" || rel == "clerkOf" || rel == "judgedBy" || rel == "clerkedBy"
   end
 
   def _omitted_label(persname, children)

--- a/app/views/people/network.html.erb
+++ b/app/views/people/network.html.erb
@@ -94,7 +94,12 @@
             <li class="rtype_missing"><span>Unknown</span></li>
           </ul>
           
-          <p>Visualizations show relationships to two degrees out, and do not contain judge and clerk relationships.</p>
+          <p>Visualizations do not contain judge and clerk relationships due to the large number of largely impersonal results.</p>
+          <% if @notes.present? %>
+            <p><%= @notes %></p>
+          <% else %>
+            <p>Displaying relationships two degrees out from selected individual.</p>
+          <% end %>
         </div> <!-- /key -->
       </div><!-- /inner -->
     </div><!-- /left-container -->

--- a/app/views/people/network.html.erb
+++ b/app/views/people/network.html.erb
@@ -93,23 +93,21 @@
             <li class="rtype_multiple"><span>Multiple</span></li>
             <li class="rtype_missing"><span>Unknown</span></li>
           </ul>
-          
-          <p>Visualizations do not contain judge and clerk relationships due to the large number of largely impersonal results.</p>
-          <% if @notes.present? %>
-            <p><%= @notes %></p>
-          <% else %>
-            <p>Displaying relationships two degrees out from selected individual.</p>
-          <% end %>
         </div> <!-- /key -->
       </div><!-- /inner -->
     </div><!-- /left-container -->
 
     <% if @res && @res["children"] && @res["children"].length > 0 %>
       <div id="center-container">
+        <% if @notes.present? %>
+          <div class="vis-notice">
+            <%= @notes %>
+          </div>
+        <% end %>
         <div id="infovis"/>
       </div>
     <% else %>
-      <div id="no-relationship">
+      <div class="vis-notice">
         <h4>No relationships of this type found. Network may be currently unavailable.</h4>
       </div>
     <% end %> 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -166,8 +166,15 @@
         <div class="alert alert-danger" id="visualizations">Relationships currently unavailable</div>
       <% else %>
         <% if @rdfresults && @rdfresults["results"]["bindings"].length > 0 %>
-	        <%= link_to "<div class='btn btn-default btn-lg btn-block' id='visualizations'>Visualize Relationships</div>".html_safe, network_vis_path(@person["id"]), class: "visualize_link", role: "button"  %>
-	  
+	        <%= link_to network_vis_path(@person["id"]), class: "visualize_link", role: "button" do %>
+            <div class="btn btn-default btn-lg btn-block" id="visualizations">
+              Visualize Relationships
+            </div>
+          <% end %>
+          <div id="visualize_warning">
+            Warning: visualizations with many relationships may load slowly or crash the browser tab
+          </div>
+
           <!-- Relationships -->
           <a name="relationships"></a>
           <h3>Relationships:</h3>


### PR DESCRIPTION
Removes people with more relationships than can be reasonably displayed
Adds judges and clerks back in with this same omission labeling
Passes back notes to display to the user about what has been altered from the default visualization